### PR TITLE
windows makefile support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,18 @@ GOBUILD=go build
 
 DEPEND=github.com/Masterminds/glide
 
+ifeq ($(OS),Windows_NT)
+    RM = rmdir /s /q build 2>nul
+	BUILD_WIN = set GOOS=windows; set GOARCH=amd64
+	BUILD_LINUX = set GOOS=linux; set GOARCH=amd64
+	BUILD_OSX = set GOOS=darwin; set GOARCH=amd64
+else
+    RM = rm -rf build/*
+	BUILD_WIN = GOOS=windows GOARCH=amd64
+	BUILD_LINUX = GOOS=linux GOARCH=amd64
+	BUILD_OSX = GOOS=darwin GOARCH=amd64
+endif
+
 # Command to get glide, you need to run it only once
 .PHONY: get_glide
 get_glide:
@@ -25,23 +37,29 @@ test:
 .PHONY: clean
 clean:
 	$(info * Cleaning build folder)
-	@rm -rf build/*
+	$(@shell if exist build $(RM))
 
 # Building linux binaries
 .PHONY: _build_linux
 _build_linux:
 	$(info * Building executable for linux x64 [$(SOURCE) -> build/linux_x64/$(NAME)])
-	@GOOS=linux GOARCH=amd64 $(GOBUILD) -o build/linux_x64/$(NAME) $(SOURCE)
+	@ $(@shell BUILD_LINUX) $(GOBUILD) -o build/linux_x64/$(NAME) $(SOURCE)
 
 # Building osx binaries
 .PHONY: _build_osx
 _build_osx:
 	$(info * Building executable for osx x64 [$(SOURCE) -> build/darwin_amd64/$(NAME)])
-	@GOOS=darwin GOARCH=amd64 $(GOBUILD) -o build/darwin_amd64/$(NAME) $(SOURCE)
+	@ $(@shell BUILD_OSX) $(GOBUILD) -o build/darwin_amd64/$(NAME) $(SOURCE)
+
+# Building windows binaries
+.PHONY: _build_windows
+_build_windows:
+	$(info * Building executable for windows x64 [$(SOURCE) -> build/win64/$(NAME)])
+	@ $(@shell BUILD_WIN) $(GOBUILD) -o build/win64/$(NAME).exe $(SOURCE)	
 
 # Clean the build folder and then build executable for linux and osx
 .PHONY: build
-build: clean _build_linux _build_osx
+build: clean _build_windows _build_linux _build_osx
 
 # Run the application
 .PHONY: run


### PR DESCRIPTION
So I've added support for windows. Now you can type make _build_windows and it will build dirsearch for windows or you can just type make build and it'll build for linux && mac os && windows.